### PR TITLE
Add autoLogin option to adminAuth

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,7 @@ module.exports = (options) => {
         type: 'strategy',
         strategy: {
             name: 'FlowForge',
+            autoLogin: true,
             label: 'Sign in',
             strategy: Strategy,
             options: {


### PR DESCRIPTION
This fixed https://github.com/flowforge/flowforge-nr-launcher/issues/31 - raised in the wrong repo originally as I forgot it would be provided by the auth plugin and not the core launcher.

This only does anything when used with Node-RED 3.x

With NR 2.x it is ignored.

