### PR TITLE
Use scope to set user permissions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,8 @@ module.exports = (options) => {
 
     const oa = new OAuth2(clientID, clientSecret, '', authorizationURL, tokenURL)
 
+    const version = require('../package.json').version
+
     const activeUsers = {}
 
     function addUser (username, profile, refreshToken, expiresIn) {
@@ -56,13 +58,13 @@ module.exports = (options) => {
                 tokenURL,
                 callbackURL: callbackURL,
                 userInfoURL: userInfoURL,
-                scope: 'editor',
+                scope: `editor-${version}`,
                 clientID: clientID,
                 clientSecret: clientSecret,
                 pkce: true,
                 state: true,
                 verify: function (accessToken, refreshToken, params, profile, done) {
-                    profile.permissions = ['*']
+                    profile.permissions = [params.scope || 'read']
                     addUser(profile.username, profile, refreshToken, params.expires_in)
                     done(null, profile)
                 }


### PR DESCRIPTION
Companion PR to https://github.com/flowforge/flowforge/pull/1005

This sets the user permissions of the logged in user based on what the oauth flow returns.

It also updates the scope set in the original request to include the plugin version - that gives us some future-proofing for when we need to make changes on both sides of the handshake, the platform will know what version of auth-plugin its talking to.