### PR TITLE
Use originalUrl when storing redirect path to handle mounted apps

### DIFF
--- a/lib/httpAuthMiddleware.js
+++ b/lib/httpAuthMiddleware.js
@@ -12,7 +12,7 @@ module.exports = {
                 if (req.session.ffSession) {
                     next()
                 } else {
-                    req.session.redirectTo = req.path
+                    req.session.redirectTo = req.originalUrl
                     passport.authenticate('FlowForge', { session: false })(req, res, next)
                 }
             } catch (err) {


### PR DESCRIPTION
## Description

When applying the auth middleware to a mounted app, such as dashboard, the url in `req.path` is stripped of the mount point. This means we redirect back to the wrong place after auth.

This fix is to store `req.originalUrl` which is the unmodified path.

